### PR TITLE
Fix target noise ordering

### DIFF
--- a/postprocessing/groundtruth_results.ipynb
+++ b/postprocessing/groundtruth_results.ipynb
@@ -996,7 +996,7 @@
    "source": [
     "# Make the PairGrid\n",
     "df_plot = df_sum.copy()\n",
-    "tmp = df_plot.groupby(['target_noise','algorithm'])['symbolic_solution_rate'].mean().unstack().median()\n",
+    "tmp = df_plot.groupby(['target_noise','algorithm'])['symbolic_solution_rate'].mean().unstack().mean()\n",
     "order = tmp.sort_values(ascending=False).index\n",
     "df_plot['size_diff'] = df_plot['model_size']-df_plot['simplified_complexity']+1\n",
     "x_vars=[\n",

--- a/postprocessing/groundtruth_results.ipynb
+++ b/postprocessing/groundtruth_results.ipynb
@@ -794,7 +794,7 @@
     "    else:\n",
     "        aspect=0.55\n",
     "#     plt.figure(figsize=(8,7))\n",
-    "    tmp = df_compare.groupby(['target_noise',y])[x].apply(est).unstack().median()\n",
+    "    tmp = df_compare.groupby(['target_noise',y])[x].apply(est).unstack().mean()\n",
     "    order = tmp.sort_values(ascending=False).index\n",
     "    \n",
     "    for c in [x,y,row,col]:\n",


### PR DESCRIPTION
Currently, order is by the median across target noise levels.
Since there are 4 of them (0.0, 0.001, 0.01, 0.1), essentially the ordering was based on the avg between 0.001 and 0.01. 
I think it makes more sense to order by the mean across the 4 noise levels, hence the PR.

Perhaps median() should be called across the repeated runs, to avoid "long bars" on Test R2 which I guess are due to outliers?