### PR TITLE
Fix to issue #124

### DIFF
--- a/submission/Bingo/regressor.py
+++ b/submission/Bingo/regressor.py
@@ -69,9 +69,9 @@ def model(est, X=None):
 
     try:
         # replace X_# with data variables names
-        mapping = {'X_' + str(i): k for i, k in enumerate(X.columns)}
-        for k,v in mapping.items():
-            model_str = model_str.replace(k,v)
+        # have to iterate in reversed order to prevent X_1 in X_10 from being replaced first
+        for i, column in reversed(list(enumerate(X.columns))):
+            model_str = model_str.replace("X_" + str(i), column)
     except AttributeError:  # if X is not a pd.Dataframe
         pass
 
@@ -89,7 +89,7 @@ def get_cv_time(total_time):
 def pre_train_fn(est, X, y):
     """set max_time in seconds based on length of X."""
     if len(X) <= 1000:
-        max_time = get_cv_time(60 * 60 - 100)  # 1 hour with 100 seconds of slack
+        max_time = get_cv_time(60 * 60 - 200)  # 1 hour with 200 seconds of slack
     else:
         max_time = get_cv_time(10 * 60 * 60 - 1000)  # 10 hours with 1000 seconds of slack
     est.set_max_time(new_max_time=max_time)


### PR DESCRIPTION
I fixed the timeout issue in our source code and added more slack to cases where n<=1000 since ideally the timeout shouldn't be happening.

Also the provided string replacement code has a potential issue: say we have the model `X_10 + X_1` with the mapping `X_0: 'a', X_1: 'b', ... 'X_10': 'k'`, the provided code will turn `X_10 + X_1` into `b0 + b` rather than the intended `k + b` since it will replace all `X_1` instances with `b`. To fix this, I iterated through the variables in reversed order (see the commit). I remember seeing this code used in at least one other submission, so this might be an issue if methods are responsible for doing their own variable name replacement.