### PR TITLE
Fix ITEA and TIR and a little bit of GOMEA

### DIFF
--- a/algorithms/gpgomea/environment.yml
+++ b/algorithms/gpgomea/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - armadillo=9.900.4
   - make
   - cmake=3.28.1
-  - python=3.9
+  - python=3.10
   - eigen=3.4.0
   - python-devtools=0.9.0
   - pybind11

--- a/algorithms/gpgomea/environment.yml
+++ b/algorithms/gpgomea/environment.yml
@@ -2,6 +2,9 @@ name: gpg
 channels:
   - conda-forge
 dependencies:
+  - pkgconfig
+  - boost=1.74.0
+  - armadillo=9.900.4
   - make
   - cmake
   - python=3.9

--- a/algorithms/gpgomea/environment.yml
+++ b/algorithms/gpgomea/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - boost=1.74.0
   - armadillo=9.900.4
   - make
-  - cmake
+  - cmake=3.28.1
   - python=3.9
   - eigen=3.4.0
   - python-devtools=0.9.0

--- a/algorithms/itea/environment.yml
+++ b/algorithms/itea/environment.yml
@@ -1,0 +1,9 @@
+channels:
+    - conda-forge
+dependencies:
+    - gmp
+    - gsl 
+    - libffi 
+    - libgfortran-ng
+    - blas * openblas 
+    - liblapack

--- a/algorithms/itea/regressor.py
+++ b/algorithms/itea/regressor.py
@@ -1,3 +1,6 @@
+import sys
+import os
+os.environ["LD_LIBRARY_PATH"] = os.environ["CONDA_PREFIX"] + "/lib"
 import pyITEA as itea
 from itertools import product
 

--- a/algorithms/tir/environment.yml
+++ b/algorithms/tir/environment.yml
@@ -1,0 +1,9 @@
+channels:
+    - conda-forge
+dependencies:
+    - gmp
+    - gsl 
+    - libffi 
+    - libgfortran-ng
+    - blas * openblas 
+    - liblapack

--- a/algorithms/tir/install.sh
+++ b/algorithms/tir/install.sh
@@ -18,6 +18,7 @@ export PATH=$PATH:~/.ghcup/bin:~/.cabal/bin
 
 #conda activate srbench
 cabal install --overwrite-policy=always
+echo "python install"
 cp ~/.cabal/bin/tir ./python/
 cd python 
 pip install .

--- a/algorithms/tir/install.sh
+++ b/algorithms/tir/install.sh
@@ -17,8 +17,4 @@ curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | bash
 export PATH=$PATH:~/.ghcup/bin:~/.cabal/bin 
 
 #conda activate srbench
-cabal install --overwrite-policy=always
-echo "python install"
-cp ~/.cabal/bin/tir ./python/
-cd python 
-pip install .
+cabal install --overwrite-policy=always && cp ~/.cabal/bin/tir ./python/ && cd python && pip install .

--- a/algorithms/tir/install.sh
+++ b/algorithms/tir/install.sh
@@ -17,4 +17,4 @@ curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | bash
 export PATH=$PATH:~/.ghcup/bin:~/.cabal/bin 
 
 #conda activate srbench
-cabal install --overwrite-policy=always && cp ~/.cabal/bin/tir ./python/ && cd python && pip install .
+cabal install --overwrite-policy=always --installdir=./python && cd python && pip install .


### PR DESCRIPTION
This PR fixes ITEA and TIR:

- The `environment.yml` with additional dependencies of ITEA and TIR was missing
- TIR install script was trying to store something at the home directory, this was allowed before but now it seems the CI Actions doesn't allow anymore

GOMEA:
- I've added the `environment.yml` with the dependencies of the previous srbench. Now there are some conflicts of versions. I think if @marcovirgolin can just fix the versions of the required libs, it should work.