### PR TITLE
Adjustments to RILS-ROLS submission for new SRBENCH testing:

### DIFF
--- a/algorithms/rils-rols/install.sh
+++ b/algorithms/rils-rols/install.sh
@@ -1,2 +1,2 @@
 pip install pybind11
-pip install rils-rols==1.5.15
+pip install rils-rols==1.6.7

--- a/experiment/methods/rils-rols/regressor.py
+++ b/experiment/methods/rils-rols/regressor.py
@@ -1,12 +1,28 @@
 from rils_rols.rils_rols import RILSROLSRegressor
 from symbolic_utils import complexity as cplx
+from sklearn.base import BaseEstimator, RegressorMixin
 import sympy as sp
 
 eval_kwargs = {'scale_x': False, 'scale_y': False}
 # This is a setup for ground-truth instances (feynman and strogatz), for black-box just change max fit calls to 500k, i.e., max_fit_calls=500*1000,
 # if there is still that requirement (as in paper), otherwise keep 1 million. 
-est = RILSROLSRegressor(max_seconds=2*60*60, max_fit_calls=1000*1000, max_complexity=50, sample_size=0, verbose=True)
+est:RegressorMixin = RILSROLSRegressor(max_time=2*60*60, max_fit_calls=1000*1000, max_complexity=50, sample_size=0, verbose=True)
 
-def model(est):
-    return str(est.model_string())
+def model(est, X=None) -> str:
+    if X is None:
+        return str(est.model_string())
+    else:
+        mapping = {'x'+str(i):k for i,k in enumerate(X.columns)}
+        new_model = str(est.model_string())
+        for k,v in reversed(mapping.items()):
+            new_model = new_model.replace(k,v)
+        return new_model
 
+def complexity(est):
+    return cplx(sp.parse_expr(str(est.model_string())))
+    
+def get_population(est) -> list[RegressorMixin]:
+    return [est]
+
+def get_best_solution(est) -> RegressorMixin:
+    return est

--- a/experiment/symbolic_algs.py
+++ b/experiment/symbolic_algs.py
@@ -14,5 +14,6 @@ symbolic_algs = [
     "MRGPRegressor",
     "OperonRegressor",
     "PySRRegressor",
+    "RILSROLSRegressor",
     "sembackpropgp",
 ]


### PR DESCRIPTION
1. Added get_best_solution() and get_population() methods in the experiment/methods/rils-rols/regressor.py
Method model() is adjusted so it returns equation with original variable names. 
Also, max_time is added as argument and as attribute inside the belonging class. 

2. Updated version for install over PyPI inside algorithms/rils-rols/install.sh

3. Added "RILSROLSRegressor" inside the symbolic_algs.py list, not sure if this is used at all.