### PR TITLE
Bump actions/cache from v2 to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
           use-mamba: true
       - 
         name: Cache conda
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: /usr/share/miniconda3/envs/srbench
           key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{hashFiles('environment.yml','experiment/methods/src/*.sh')}}-${{ github.sha }}
@@ -122,7 +122,7 @@ jobs:
           use-mamba: true
       - 
         name: Cache conda
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: /usr/share/miniconda3/envs/srbench
           key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('environment.yml','experiment/methods/src/*.sh') }}-${{ github.sha }}
@@ -167,7 +167,7 @@ jobs:
           use-mamba: true
       - 
         name: Cache conda
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: /usr/share/miniconda3/envs/srbench
           key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('environment.yml','experiment/methods/src/*.sh') }}-${{ github.sha }}


### PR DESCRIPTION
GitHub now auto-fails any workflow using `actions/cache@v2` (deprecated, cache-v2 service shut down). This is currently blocking all PRs to `dev` at the **Set up job** step, before any project code runs.

This PR bumps the three `Cache conda` steps in `.github/workflows/ci.yml` (build, test_evaluate, test_tuned jobs) from `@v2` to `@v4`. No other changes.

Surfaced while debugging CI on #380.