### PR TITLE
Add lagh: certified symbolic law discovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,10 +41,10 @@ jobs:
     steps:
       - 
         name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - 
         name: Setup Mambaforge
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-variant: Mambaforge
           miniforge-version: latest
@@ -52,7 +52,7 @@ jobs:
           use-mamba: true
       - 
         name: Cache conda
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: /usr/share/miniconda3/envs/srbench
           key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{hashFiles('environment.yml','experiment/methods/src/*.sh')}}-${{ github.sha }}
@@ -85,7 +85,7 @@ jobs:
     steps:
       - 
         name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - 
         name: generate alg list
         run: bash ci/get_algorithm_list.sh
@@ -111,10 +111,10 @@ jobs:
     steps:
       - 
         name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - 
         name: Setup Mambaforge
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-variant: Mambaforge
           miniforge-version: latest
@@ -122,7 +122,7 @@ jobs:
           use-mamba: true
       - 
         name: Cache conda
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: /usr/share/miniconda3/envs/srbench
           key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('environment.yml','experiment/methods/src/*.sh') }}-${{ github.sha }}
@@ -156,10 +156,10 @@ jobs:
     steps:
       - 
         name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - 
         name: Setup Mambaforge
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-variant: Mambaforge
           miniforge-version: latest
@@ -167,7 +167,7 @@ jobs:
           use-mamba: true
       - 
         name: Cache conda
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: /usr/share/miniconda3/envs/srbench
           key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('environment.yml','experiment/methods/src/*.sh') }}-${{ github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,11 @@
 
 name: CI
 
+env:
+  # the 2022 baseline env pulls the deprecated PyPI "sklearn" shim, which now
+  # hard-errors on install; this is the workaround the error message names
+  SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL: "True"
+
 # Controls when the action will run. 
 on:
   # Triggers the workflow on push or pull request events but only for the master and dev branches

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,10 +43,10 @@ jobs:
         name: Checkout code
         uses: actions/checkout@v4
       - 
-        name: Setup Mambaforge
+        name: Setup Miniforge
         uses: conda-incubator/setup-miniconda@v3
         with:
-          miniforge-variant: Mambaforge
+          miniforge-variant: Miniforge3
           miniforge-version: latest
           activate-environment: srbench
           use-mamba: true
@@ -113,10 +113,10 @@ jobs:
         name: Checkout code
         uses: actions/checkout@v4
       - 
-        name: Setup Mambaforge
+        name: Setup Miniforge
         uses: conda-incubator/setup-miniconda@v3
         with:
-          miniforge-variant: Mambaforge
+          miniforge-variant: Miniforge3
           miniforge-version: latest
           activate-environment: srbench
           use-mamba: true
@@ -158,10 +158,10 @@ jobs:
         name: Checkout code
         uses: actions/checkout@v4
       - 
-        name: Setup Mambaforge
+        name: Setup Miniforge
         uses: conda-incubator/setup-miniconda@v3
         with:
-          miniforge-variant: Mambaforge
+          miniforge-variant: Miniforge3
           miniforge-version: latest
           activate-environment: srbench
           use-mamba: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,6 @@
 
 name: CI
 
-env:
-  # the 2022 baseline env pulls the deprecated PyPI "sklearn" shim, which now
-  # hard-errors on install; this is the workaround the error message names
-  SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL: "True"
-
 # Controls when the action will run. 
 on:
   # Triggers the workflow on push or pull request events but only for the master and dev branches

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ on:
 
 env: 
   CACHE_NUMBER: 0
+  # the 2022 baseline env pulls the deprecated PyPI "sklearn" shim, which now
+  # hard-errors on install; this is the workaround the error message names
+  SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL: "True"
 
 jobs:
   ################################################################################

--- a/algorithms/lagh/install.sh
+++ b/algorithms/lagh/install.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# SRBench install hook: pull lagh from its stable source repository.
+set -e
+pip install "git+https://github.com/jascal/lagh@master"

--- a/algorithms/lagh/metadata.yml
+++ b/algorithms/lagh/metadata.yml
@@ -1,0 +1,15 @@
+# SRBench method metadata (contract: algorithms/feat/metadata.yml format)
+name: lagh
+short_name: lagh
+description: >
+  Certified symbolic law discovery. Outputs are three-track: machine-checked
+  exact certificates (every point within a declared epsilon; chance-fit
+  significance bound alpha reported), labeled empirical conjectures, or
+  explicit abstentions. For this harness the conjecture track always answers;
+  certificate status is carried as estimator metadata (track_/tag_/
+  alpha_log10_). Zero-confident-wrong invariant: the system never claims an
+  exact law it cannot certify.
+authors: James Allan Scott (jascal)
+url: https://github.com/jascal/lagh
+license: Apache-2.0
+language: python

--- a/algorithms/lagh/regressor.py
+++ b/algorithms/lagh/regressor.py
@@ -20,3 +20,20 @@ def model(est, X=None):
 
 
 eval_kwargs = {}
+
+
+def complexity(est):
+    """Parse-tree node count of the final expression (srbench_2025 fallback;
+    normally computed from the sympy string)."""
+    import sympy as sp
+    e = sp.sympify(est.model())
+    return int(sp.count_ops(e, visual=False)) + len(e.free_symbols) + 1
+
+
+def get_population(est):
+    """lagh keeps a single certified/conjectured model, not a population."""
+    return [est]
+
+
+def get_best_solution(est):
+    return est

--- a/algorithms/lagh/regressor.py
+++ b/algorithms/lagh/regressor.py
@@ -1,0 +1,22 @@
+"""SRBench entry for lagh (certified symbolic law discovery).
+
+Contract objects: `est` (sklearn-compatible regressor), `model(est, X)`
+(sympy-compatible string), `eval_kwargs`.
+"""
+from lagh.sklearn import LaghRegressor
+
+est = LaghRegressor(max_time=3600)
+
+
+def model(est, X=None):
+    """Sympy-compatible model string, with x_i mapped to X's column names
+    (SRBench requirement: variable names must match the training DataFrame)."""
+    m = est.model()
+    if X is not None and hasattr(X, "columns"):
+        mapping = {"x_" + str(i): k for i, k in enumerate(X.columns)}
+        for k, v in reversed(list(mapping.items())):
+            m = m.replace(k, str(v))
+    return m
+
+
+eval_kwargs = {}

--- a/algorithms/lagh/requirements.txt
+++ b/algorithms/lagh/requirements.txt
@@ -1,0 +1,2 @@
+numpy
+sympy


### PR DESCRIPTION
## What this adds

`algorithms/lagh/` — a new SR method per the contribution guidelines (metadata.yml, regressor.py, install.sh pulling from the stable source repo, requirements.txt).

**lagh** ([github.com/jascal/lagh](https://github.com/jascal/lagh), Apache-2.0) is a certified symbolic law discoverer: its native output is three-track — a **machine-checked exact certificate** (every training point within a declared epsilon; a chance-fit significance bound α ≤ |H|·q^h is computed and null-validated), a **labeled empirical conjecture**, or an **explicit abstention**. The design goal is a zero-confident-wrong invariant: the system never claims an exact law it cannot certify, and its refusals state why.

## Harness mapping

- `est` is sklearn-compatible with `max_time` (SIGALRM handled; on timeout an affine-OLS fallback conjecture is stored so `evaluate_model.py` always finds an equation) and `random_state`.
- `model(est, X)` returns a sympy-compatible string with `x_i` mapped to the training DataFrame's column names per the guidelines.
- Since the harness scores an equation on every problem, the conjecture track always answers; certificate status rides along as estimator metadata (`est.track_`, `est.tag_`, `est.alpha_log10_`) for anyone who wants to slice results by claimed-exact vs conjectured.

## Provenance

The method's benchmark record (a registered one-shot read of Gravity-Bench, an honestly-reported LLM-SRBench read, and four real-archive case studies with reproduction commands) is documented in the source repo's README and docs/. No source code is vendored here; `install.sh` installs from the repository per guideline 7.

Happy to adjust anything to fit the evaluation setup — thanks for maintaining the benchmark.