### PR TITLE
Fix target_noise/feature_noise not passed through in --local entry po…

### DIFF
--- a/experiment/evaluate_model.py
+++ b/experiment/evaluate_model.py
@@ -382,5 +382,7 @@ if __name__ == '__main__':
         algorithm=algorithm,
         test=args.TEST,
         fit_time_limit=args.FITTIME,
+        target_noise=args.Y_NOISE,
+        feature_noise=args.X_NOISE,
         **eval_kwargs
     )


### PR DESCRIPTION
Fixes #216

   `-target_noise` and `-feature_noise` are parsed into `args.Y_NOISE`/`args.X_NOISE`
   but were never forwarded to `evaluate_model()`, so `--local` runs silently
   ignored requested noise levels and always evaluated on clean data.

   This adds the two missing keyword arguments to the call site.